### PR TITLE
Feat: Show sheet filenames

### DIFF
--- a/data/com.github.kmwallio.thiefmd.gschema.xml
+++ b/data/com.github.kmwallio.thiefmd.gschema.xml
@@ -113,6 +113,10 @@
             <default>false</default>
             <summary>Persist Library Order between launches</summary>
         </key>
+        <key name="show-sheet-filenames" type="b">
+            <default>false</default>
+            <summary>Always show sheet filenames</summary>
+        </key>
         <key name="spacing" type="i">
             <default>4</default>
             <summary>The spacing on the Editor View's lines</summary>

--- a/src/Constants/AppSettings.vala
+++ b/src/Constants/AppSettings.vala
@@ -136,6 +136,7 @@ First time here?  Drag a folder into the library, or click on the Folder icon to
         public bool dark_mode { get; set; }
         public bool ui_editor_theme { get; set; }
         public bool save_library_order { get; set; }
+        public bool show_sheet_filenames { get; set; }
         public bool export_break_folders { get; set; }
         public bool export_break_sheets { get; set; }
         public bool export_resolve_paths { get; set; }
@@ -379,6 +380,7 @@ First time here?  Drag a folder into the library, or click on the Folder icon to
             app_settings.bind ("ui-editor-theme", this, "ui_editor_theme", SettingsBindFlags.DEFAULT);
             app_settings.bind ("brandless", this, "brandless", SettingsBindFlags.DEFAULT);
             app_settings.bind ("save-library-order", this, "save_library_order", SettingsBindFlags.DEFAULT);
+            app_settings.bind ("show-sheet-filenames", this, "show_sheet_filenames", SettingsBindFlags.DEFAULT);
             app_settings.bind ("export-break-folders", this, "export_break_folders", SettingsBindFlags.DEFAULT);
             app_settings.bind ("export-break-sheets", this, "export_break_sheets", SettingsBindFlags.DEFAULT);
             app_settings.bind ("export-resolve-paths", this, "export_resolve_paths", SettingsBindFlags.DEFAULT);

--- a/src/Widgets/Preferences.vala
+++ b/src/Widgets/Preferences.vala
@@ -849,6 +849,22 @@ namespace ThiefMD.Widgets {
             preserve_library.add (perserve_library_label);
             thiefmd_options.add (preserve_library);
 
+            var sheet_filename = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 12);
+            var sheet_filename_switch = new Switch ();
+            sheet_filename_switch.set_active (settings.show_sheet_filenames);
+            sheet_filename_switch.notify["active"].connect (() => {
+                settings.show_sheet_filenames = sheet_filename_switch.get_active ();
+            });
+            sheet_filename_switch.tooltip_text = _("Toggle always show sheet filenames");
+            sheet_filename_switch.margin = 12;
+            var sheet_filename_label = new Label(_("Always show sheet filenames"));
+            sheet_filename_label.xalign = 0;
+            sheet_filename_label.margin = 12;
+            sheet_filename_label.set_line_wrap (true);
+            sheet_filename.add (sheet_filename_switch);
+            sheet_filename.add (sheet_filename_label);
+            thiefmd_options.add (sheet_filename);
+
             var experimental_mode = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 12);
             var experimental_mode_switch = new Switch ();
             experimental_mode_switch.set_active (settings.experimental);

--- a/src/Widgets/Sheet.vala
+++ b/src/Widgets/Sheet.vala
@@ -146,12 +146,18 @@ namespace ThiefMD.Widgets {
         public void redraw () {
             var settings = AppSettings.get_default ();
             string file_contents = FileManager.get_file_lines_yaml (_sheet_path, settings.num_preview_lines, true, out _sheet_title, out _sheet_date);
+            string file_title = "<b>" + _sheet_path.substring(_sheet_path.last_index_of (Path.DIR_SEPARATOR_S) + 1) + "</b>";
 
             _word_count = FileManager.get_word_count (_sheet_path);
             if (file_contents.chomp() != "" && settings.num_preview_lines != 0) {
-                _label_buffer = "<small>" + SheetManager.mini_mark(file_contents) + "</small>";
+                string content_preview = "<small>" + SheetManager.mini_mark(file_contents) + "</small>";
+                if (settings.show_sheet_filenames) {
+                    _label_buffer = file_title + "\n" + content_preview;
+                } else {
+                    _label_buffer = content_preview;
+                }
             } else {
-                _label_buffer = "<b>" + _sheet_path.substring(_sheet_path.last_index_of (Path.DIR_SEPARATOR_S) + 1) + "</b>";
+                _label_buffer = file_title;
             }
 
             _label.set_label (_label_buffer);

--- a/tests/TestSettings.vala
+++ b/tests/TestSettings.vala
@@ -289,6 +289,7 @@ First time here?  Drag a folder into the library, or click on the Folder icon to
         public bool dark_mode { get; set; default = false; }
         public bool ui_editor_theme { get; set; default = false; }
         public bool save_library_order { get; set; default = true; }
+        public bool show_sheet_filenames { get; set; default = true; }
         public bool export_break_folders { get; set; default = false; }
         public bool export_break_sheets { get; set; default = false; }
         public bool export_resolve_paths { get; set; default = false; }


### PR DESCRIPTION
Closes #174

This adds optional filename titles to the sheet list. The setting is off by default.

The issue asked for replacing the preview with filename, but found it more useful to show both.

<details>
<summary> Screenshots </summary>

**On:**
![image](https://github.com/user-attachments/assets/047d8998-005b-4c66-86be-ef077a83a04a)

**Off (exact same as before):**
![image](https://github.com/user-attachments/assets/46b7ed64-203a-43ae-ab97-2f00242cb344)

**Settings toggle:**
![image](https://github.com/user-attachments/assets/5e168164-13e0-4ee7-a179-5dde4d4120dd)

</details>

I couldn't build a flatpak to test if these changes break it. They really shouldn't, but I'll just point mention it.