### PR TITLE
misc: Adwaita about dialog

### DIFF
--- a/src/Widgets/About.vala
+++ b/src/Widgets/About.vala
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2020 kmwallio
- * 
- * Modified September 2, 2020
+ *
+ * Modified February 17, 2026
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,20 +23,18 @@ using Gtk;
 using Gdk;
 
 namespace ThiefMD.Widgets {
-public class About : Gtk.Window {
+    public class About : Adw.Dialog {
         private Gtk.Stack stack;
-        private Gtk.HeaderBar bar;
+        private Adw.HeaderBar header;
+        private Adw.ToolbarView toolbar_view;
 
         public About () {
-            set_transient_for (ThiefApp.get_instance ());
-            resizable = false;
-            modal = true;
             build_ui ();
         }
 
         private void build_ui () {
-            add_headerbar ();
-            title = "";
+            toolbar_view = new Adw.ToolbarView ();
+            set_child (toolbar_view);
 
             stack = new Stack ();
             stack.add_titled (build_about_ui (), _("About ThiefMD"), _("About"));
@@ -45,21 +43,17 @@ public class About : Gtk.Window {
             StackSwitcher switcher = new StackSwitcher ();
             switcher.set_stack (stack);
             switcher.halign = Align.CENTER;
+            toolbar_view.set_content (stack);
 
-            Box box = new Box (Orientation.VERTICAL, 0);
+            header = new Adw.HeaderBar ();
+            header.set_title_widget (switcher);
+            toolbar_view.add_top_bar (header);
 
-            bar.set_title_widget (switcher);
-            box.append (stack);
-            set_child (box);
+            height_request = 450;
 
-            set_default_size (450, 450);
-
-            close_request.connect (() => {
+            closed.connect (() => {
                 destroy ();
-                return true;
             });
-
-            present ();
         }
 
         private Gtk.Grid build_about_ui () {
@@ -73,29 +67,29 @@ public class About : Gtk.Window {
             grid.orientation = Orientation.VERTICAL;
             grid.hexpand = true;
 
-            //  program_name = ThiefProperties.NAME;
+            // program_name = ThiefProperties.NAME;
             var name_label = new Gtk.Label (ThiefProperties.NAME);
             name_label.hexpand = true;
             grid.attach (name_label, 1, 2);
-            //  comments = ThiefProperties.TAGLINE;
+            // comments = ThiefProperties.TAGLINE;
             var tag_label = new Gtk.Label (ThiefProperties.TAGLINE);
             tag_label.hexpand = true;
             grid.attach (tag_label, 1, 4);
-            //  copyright = ThiefProperties.COPYRIGHT;
+            // copyright = ThiefProperties.COPYRIGHT;
             var copy_label = new Gtk.Label ("<small>" + ThiefProperties.COPYRIGHT + "</small>");
             copy_label.hexpand = true;
             copy_label.use_markup = true;
             grid.attach (copy_label, 1, 6);
-            //  version = ThiefProperties.VERSION;
+            // version = ThiefProperties.VERSION;
             var version_label = new Gtk.Label (ThiefProperties.VERSION);
             version_label.hexpand = true;
             grid.attach (version_label, 1, 3);
-            //  website = ThiefProperties.URL;
+            // website = ThiefProperties.URL;
             var website_label = new Gtk.Label ("<a href='" + ThiefProperties.URL + "'>" + ThiefProperties.URL + "</a> - <a href='https://github.com/kmwallio/ThiefMD/discussions'>" + _("Feedback") + "</a>");
             website_label.hexpand = true;
             website_label.use_markup = true;
             grid.attach (website_label, 1, 5);
-            //  license_type = ThiefProperties.LICENSE_TYPE;
+            // license_type = ThiefProperties.LICENSE_TYPE;
             var lic_label = new Gtk.Label ("<small>" + _("This program comes with absolutely no warranty.") + "</small>");
             var lic_label2 = new Gtk.Label ("<small>" + _("See the <a href='https://www.gnu.org/licenses/gpl-3.0.html'>GNU General Public License, version 3 or later</a> for details.") + "</small>");
             lic_label.hexpand = true;
@@ -136,6 +130,7 @@ public class About : Gtk.Window {
                 i++;
                 return true;
             });
+            scrl.hscrollbar_policy = Gtk.PolicyType.NEVER;
             scrl.hexpand = true;
             scrl.vexpand = true;
             scrl.set_child (scrl_grid);
@@ -143,18 +138,6 @@ public class About : Gtk.Window {
             grid.attach (scrl, 0, 0);
 
             return grid;
-        }
-
-        public void add_headerbar () {
-            bar = new Gtk.HeaderBar ();
-            bar.set_show_title_buttons (true);
-            bar.set_title_widget (new Gtk.Label (""));
-
-            this.set_titlebar (bar);
-        }
-
-        public void run () {
-            present ();
         }
     }
 }

--- a/src/Widgets/QuickPreferences.vala
+++ b/src/Widgets/QuickPreferences.vala
@@ -135,8 +135,7 @@ namespace ThiefMD.Widgets {
             about_button.has_tooltip = true;
             about_button.tooltip_text = _("About ThiefMD");
             about_button.clicked.connect (() => {
-                About abt = new About();
-                abt.run ();
+                new About ().present (ThiefApp.get_instance ());
             });
 
             menu_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 6);


### PR DESCRIPTION
Changes:

About dialog now inherits purpose-built Adw.Dialog instead of Gtk.Window, making it more obviously modal. As a side effect, this also fixes broken styling in the close button.

https://github.com/user-attachments/assets/e1ad9a8d-8ff2-4652-b074-6e6dc9d52cc7

Notes:

Libadwaita also provides a premade about dialog: https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/class.AboutDialog.html

Oh, and, I'm glad you're back.