### PR TITLE
Add Image Previews on hover (in experiemental mode)

### DIFF
--- a/data/com.github.kmwallio.thiefmd.appdata.xml
+++ b/data/com.github.kmwallio.thiefmd.appdata.xml
@@ -66,7 +66,10 @@
       <description>
         <p>From experimental to normal, and some new experiments.</p>
         <ul>
-          <li>.</li>
+          <li>Image previews - Hover over an image tag, and we'll show what it looks like.</li>
+          <li>libmarkdown3 (Discount 3) - More markdown, better support. We're living in the future today.</li>
+          <li>About Dialog Fixes - Thanks sevonj!</li>
+          <li>Bug fixes.</li>
         </ul>
       </description>
       <url>https://github.com/kmwallio/ThiefMD/releases/tag/v0.3.1</url>

--- a/flatpak/com.github.kmwallio.thiefmd.json
+++ b/flatpak/com.github.kmwallio.thiefmd.json
@@ -28,18 +28,7 @@
         "*.la",
         "*grammar.a"
     ],
-    "modules": [{
-            "name": "gtksourceview",
-            "buildsystem": "meson",
-            "cleanup": [
-                "*.a"
-            ],
-            "sources": [{
-                "type": "archive",
-                "url": "https://download.gnome.org/sources/gtksourceview/5.14/gtksourceview-5.14.2.tar.xz",
-                "sha256": "1a6d387a68075f8aefd4e752cf487177c4a6823b14ff8a434986858aeaef6264"
-            }]
-        },
+    "modules": [
         "shared-modules/intltool/intltool-0.51.json",
         {
             "name": "libspelling",
@@ -124,27 +113,6 @@
                     "type" : "archive",
                     "url" : "https://github.com/opencog/link-grammar/archive/refs/tags/link-grammar-5.13.0.tar.gz",
                     "sha256" : "a545b7efb7aceab2d8ad301466f199778a3da712928999ed8d66deb32ca3184f"
-                }
-            ]
-        },
-        {
-            "name" : "libadwaita",
-            "buildsystem" : "meson",
-            "cleanup": [
-                "*.a"
-            ],
-            "config-opts" : [
-                "-Dexamples=false",
-                "-Dprofiling=false",
-                "-Dintrospection=enabled",
-                "-Dtests=false",
-                "-Dvapi=true"
-            ],
-            "sources" : [
-                {
-                    "type": "archive",
-                    "url": "https://download.gnome.org/sources/libadwaita/1.6/libadwaita-1.6.2.tar.xz",
-                    "sha256": "7542f8354e6808dd4e9a31551bbdfc0170735e4af4d1b3e69186500ccb9c01eb"
                 }
             ]
         },

--- a/src/Enrichments/Markdown.vala
+++ b/src/Enrichments/Markdown.vala
@@ -466,9 +466,12 @@ namespace ThiefMD.Enrichments {
             switch (key.down ()) {
                 case "coverimage":
                 case "cover_image":
+                case "cover-image":
                 case "cover":
                 case "featured_image":
                 case "feature_image":
+                case "featured-image":
+                case "feature-image":
                 case "image":
                 case "thumbnail":
                 case "thumb":
@@ -573,15 +576,15 @@ namespace ThiefMD.Enrichments {
         }
 
         private void get_preview_max_size (out int max_w, out int max_h) {
-            max_w = 240;
-            max_h = 200;
+            max_w = 640;
+            max_h = 480;
             int editor_w = view.get_allocated_width ();
             int editor_h = view.get_allocated_height ();
             if (editor_w > 0) {
-                max_w = int.max (120, (int) (editor_w * 0.35));
+                max_w = int.max (640, (int) (editor_w * 0.65));
             }
             if (editor_h > 0) {
-                max_h = int.max (90, (int) (editor_h * 0.35));
+                max_h = int.max (480, (int) (editor_h * 0.65));
             }
         }
 

--- a/src/Enrichments/Markdown.vala
+++ b/src/Enrichments/Markdown.vala
@@ -233,35 +233,6 @@ namespace ThiefMD.Enrichments {
         }
     }
 
-    /**
-     * Holds a child anchor inserted into the buffer to show an image preview,
-     * along with the URL it was loaded from.
-     */
-    private class ImagePreviewEntry : Object {
-        public Gtk.TextChildAnchor anchor;
-        public Gtk.Picture picture;
-        public int line_num;
-        public string url;
-
-        public ImagePreviewEntry (Gtk.TextChildAnchor a, Gtk.Picture p, int line, string u) {
-            anchor = a;
-            picture = p;
-            line_num = line;
-            url = u;
-        }
-    }
-
-    /** Pending image insert: target line number, raw URL, resolved file path. */
-    private class PendingImageInsert : Object {
-        public int line_num;
-        public string img_url;
-        public string img_path;
-
-        public PendingImageInsert (int l, string u, string p) {
-            line_num = l; img_url = u; img_path = p;
-        }
-    }
-
     public class MarkdownEnrichment : Object {
         private GtkSource.CompletionWords? source_completion;
         private BibTexCompletionProvider? bibtex_provider;
@@ -303,16 +274,6 @@ namespace ThiefMD.Enrichments {
         private string checking_copy;
         private TimedMutex limit_updates;
 
-        // Image preview state (experimental mode only)
-        private Gee.ArrayList<ImagePreviewEntry> image_previews;
-        private bool updating_images = false;
-        private bool image_update_pending = false;
-        private uint image_update_idle_id = 0;
-        private bool image_preview_ready = false;
-        private bool initializing_attach = false;
-        private bool image_preview_edit_gate = false;
-        private ulong image_preview_edit_handler_id = 0;
-
         private int last_cursor;
         private int copy_offset;
         private int hashtag_w;
@@ -335,7 +296,7 @@ namespace ThiefMD.Enrichments {
             try {
                 is_url = new Regex ("^(http|ftp|ssh|mailto|tor|torrent|vscode|atom|rss|file)?s?(:\\/\\/)?(www\\.)?([a-zA-Z0-9\\.\\-]+)\\.([a-z]+)([^\\s]+)$", RegexCompileFlags.CASELESS, 0);
                 is_markdown_url = new Regex ("(?<text_group>\\[(?>[^\\[\\]]+|(?&text_group))+\\])(?:\\((?<url>\\S+?)(?:[ ]\"(?<title>(?:[^\"]|(?<=\\\\)\")*?)\")?\\))", RegexCompileFlags.CASELESS, 0);
-                // Matches image tags: ![alt text](url) — used for inline preview
+                // Matches image tags: ![alt text](url) — used for hover tooltip preview
                 is_image = new Regex ("!\\[([^\\]]*)\\]\\(([^)]+)\\)", RegexCompileFlags.CASELESS, 0);
                 // Matches HTML image tags like: <img src="path/to/image.png" ...>
                 is_html_image = new Regex ("<img\\b[^>]*\\bsrc\\s*=\\s*[\\\"']([^\\\"']+)[\\\"'][^>]*>", RegexCompileFlags.CASELESS, 0);
@@ -352,7 +313,6 @@ namespace ThiefMD.Enrichments {
             markup_inserted_around_selection = false;
             active_selection = false;
             last_cursor = -1;
-            image_previews = new Gee.ArrayList<ImagePreviewEntry> ();
         }
 
         private void tag_code_blocks () {
@@ -1045,8 +1005,6 @@ namespace ThiefMD.Enrichments {
 
             last_cursor = current_cursor;
             checking.unlock ();
-
-            // Inline image previews are disabled; images are shown via hover tooltip.
         }
 
         private void clear_markup_navigation () {
@@ -1302,21 +1260,6 @@ namespace ThiefMD.Enrichments {
                 return false;
             }
 
-            if (image_update_idle_id != 0) {
-                GLib.Source.remove (image_update_idle_id);
-                image_update_idle_id = 0;
-            }
-            if (image_preview_edit_handler_id != 0 && buffer != null) {
-                SignalHandler.disconnect (buffer, image_preview_edit_handler_id);
-                image_preview_edit_handler_id = 0;
-            }
-            image_update_pending = false;
-            updating_images = false;
-            image_preview_ready = false;
-            initializing_attach = true;
-            image_preview_edit_gate = false;
-            image_previews.clear ();
-
             view = textview;
             buffer = textview.get_buffer ();
 
@@ -1326,17 +1269,6 @@ namespace ThiefMD.Enrichments {
             }
 
             var settings = AppSettings.get_default ();
-
-            image_preview_edit_handler_id = buffer.changed.connect (() => {
-                if (!image_preview_edit_gate) {
-                    image_preview_edit_gate = true;
-                    recheck_all ();
-                }
-                if (image_preview_edit_handler_id != 0 && buffer != null) {
-                    SignalHandler.disconnect (buffer, image_preview_edit_handler_id);
-                    image_preview_edit_handler_id = 0;
-                }
-            });
 
             view.destroy.connect (detach);
 
@@ -1355,7 +1287,6 @@ namespace ThiefMD.Enrichments {
             active_selection = false;
 
             settings_updated ();
-            initializing_attach = false;
             settings.changed.connect (settings_updated);
 
             last_cursor = -1;
@@ -1382,17 +1313,10 @@ namespace ThiefMD.Enrichments {
                 buffer.notify["cursor-position"].connect (cursor_update_heading_margins);
                 markdown_url.invisible = true;
                 markdown_url.invisible_set = true;
-                if (!image_preview_ready && !initializing_attach) {
-                    image_preview_ready = true;
-                    recheck_all ();
-                }
             } else {
                 buffer.notify["cursor-position"].disconnect (cursor_update_heading_margins);
                 markdown_url.invisible = false;
                 markdown_url.invisible_set = false;
-                // Toss any image previews — they're an experimental-only treat
-                remove_all_image_previews ();
-                image_preview_ready = false;
             }
 
             // Update BibTeX provider based on experimental mode
@@ -1552,30 +1476,7 @@ namespace ThiefMD.Enrichments {
             }
         }
 
-        /**
-         * Resolve an image URL to an absolute local file path.
-         * Relative paths are resolved against the directory of the current file.
-         * Returns an empty string if the URL looks remote or can't be resolved.
-         */
-        /**
-         * Remove every image preview widget from the buffer and clear the tracking list.
-         * Deletes bottom-to-top so earlier deletions don't shift later iters.
-         * Must be called from the main thread (it modifies the buffer).
-         */
-        private void remove_all_image_previews () {
-            if (image_previews == null) {
-                return;
-            }
-
-            foreach (var entry in image_previews) {
-                if (entry.picture != null) {
-                    entry.picture.unparent ();
-                }
-            }
-
-            image_previews.clear ();
-        }
-
+        /** Load an image from disk, scale it to fit max_w/max_h, and return a texture. Returns null if the image cannot be loaded. */
         private Gdk.Texture? load_preview_texture (string img_path, int max_w, int max_h) {
             try {
                 var pixbuf = new Gdk.Pixbuf.from_file_at_scale (img_path, max_w, max_h, true);
@@ -1586,186 +1487,8 @@ namespace ThiefMD.Enrichments {
             }
         }
 
-        /**
-         * Scan the buffer for image tags and sync preview widgets.
-         * Scheduled via GLib.Idle so it never runs inside recheck_all().
-         * Only active in experimental mode.
-         *
-         * Key design: all buffer inserts are done bottom-to-top (highest line
-         * number first) so that each insertion doesn't shift the line numbers
-         * of subsequent insert points. This avoids the cjhtextregion assertion
-         * crash caused by stale buffer offsets.
-         */
-        private bool update_image_previews () {
-            image_update_idle_id = 0;
-            image_update_pending = false;
-
-            var settings = AppSettings.get_default ();
-            if (!settings.experimental || !image_preview_ready || buffer == null || view == null) {
-                return GLib.Source.REMOVE;
-            }
-
-            // Don't let buffer edits below trigger another update loop
-            updating_images = true;
-            debug ("Image preview sync start: lines=%d chars=%d tracked=%d",
-                buffer.get_line_count (), buffer.get_char_count (), image_previews.size);
-
-            // Figure out where the cursor lives so we can skip that line
-            var cursor_mark = buffer.get_insert ();
-            Gtk.TextIter cursor_iter;
-            buffer.get_iter_at_mark (out cursor_iter, cursor_mark);
-            int cursor_line = cursor_iter.get_line ();
-
-            // --- Step 1: Drop stale preview entries without mutating buffer text ---
-            var still_good = new Gee.ArrayList<ImagePreviewEntry> ();
-
-            foreach (var entry in image_previews) {
-                if (entry.anchor.get_deleted ()) {
-                    if (entry.picture != null) {
-                        entry.picture.unparent ();
-                    }
-                    continue;
-                }
-
-                if (entry.line_num < 0 || entry.line_num >= buffer.get_line_count ()) {
-                    if (entry.picture != null) {
-                        entry.picture.unparent ();
-                    }
-                    continue;
-                }
-
-                Gtk.TextIter line_start, line_end;
-                buffer.get_iter_at_line (out line_start, entry.line_num);
-                line_end = line_start;
-                line_end.forward_to_line_end ();
-                string line_text = buffer.get_text (line_start, line_end, false);
-
-                bool still_valid = false;
-                try {
-                    MatchInfo mi;
-                    if (is_image.match (line_text, 0, out mi)) {
-                        still_valid = (mi.fetch (2) == entry.url) && (entry.line_num != cursor_line);
-                    }
-                } catch (Error e) {}
-
-                if (still_valid) {
-                    still_good.add (entry);
-                } else {
-                    if (entry.picture != null) {
-                        entry.picture.unparent ();
-                    }
-                }
-            }
-
-            image_previews = still_good;
-
-            // --- Step 2: Scan line-by-line for image tags that need previews ---
-            var previewed_lines = new Gee.HashSet<int> ();
-            foreach (var entry in image_previews) {
-                if (!entry.anchor.get_deleted ()) {
-                    previewed_lines.add (entry.line_num);
-                }
-            }
-
-            // Collect (line_number, url, resolved_path) for lines that need a new preview
-            var pending_inserts = new Gee.ArrayList<PendingImageInsert> ();
-
-            Gtk.TextIter line_iter;
-            buffer.get_start_iter (out line_iter);
-            do {
-                int line_num = line_iter.get_line ();
-
-                if (line_num == cursor_line || previewed_lines.contains (line_num)) {
-                    continue;
-                }
-
-                if (line_iter.has_tag (code_block)) {
-                    continue;
-                }
-
-                Gtk.TextIter line_end = line_iter;
-                line_end.forward_to_line_end ();
-                string line_text = buffer.get_text (line_iter, line_end, false);
-
-                MatchInfo mi;
-                try {
-                    if (is_image.match (line_text, 0, out mi)) {
-                        string img_url = mi.fetch (2);
-                        string img_path = resolve_image_path (img_url);
-                        // find_file returns url unchanged when nothing found
-                        if (img_path != img_url || GLib.FileUtils.test (img_path, GLib.FileTest.EXISTS)) {
-                            pending_inserts.add (new PendingImageInsert (line_num, img_url, img_path));
-                        }
-                    }
-                } catch (Error e) {}
-            } while (line_iter.forward_line ());
-
-            // --- Step 3: Insert anchors bottom-to-top ---
-            // Sort by descending line number so earlier inserts don't shift later positions.
-            pending_inserts.sort ((a, b) => b.line_num - a.line_num);
-
-            foreach (var info in pending_inserts) {
-                int line_num = info.line_num;
-                string img_url = info.img_url;
-                string img_path = info.img_path;
-
-                int max_inline_w, max_inline_h;
-                get_preview_max_size (out max_inline_w, out max_inline_h);
-
-                Gdk.Texture? texture = load_preview_texture (img_path, max_inline_w, max_inline_h);
-                if (texture == null) {
-                    continue;
-                }
-
-                // Get a fresh iter at the end of the target line — always valid
-                // because we're going bottom-to-top and haven't touched this line yet.
-                Gtk.TextIter insert_pos;
-                buffer.get_iter_at_line (out insert_pos, line_num);
-                insert_pos.forward_to_line_end ();
-
-                var anchor = buffer.create_child_anchor (insert_pos);
-                var picture = new Gtk.Picture.for_paintable (texture);
-                picture.content_fit = Gtk.ContentFit.SCALE_DOWN;
-                picture.width_request = max_inline_w;
-                picture.height_request = max_inline_h;
-                picture.can_shrink = true;
-                view.add_child_at_anchor (picture, anchor);
-
-                image_previews.add (new ImagePreviewEntry (anchor, picture, line_num, img_url));
-                previewed_lines.add (line_num);
-            }
-
-            debug ("Image preview sync end: inserted=%d tracked=%d",
-                pending_inserts.size, image_previews.size);
-            updating_images = false;
-            return GLib.Source.REMOVE;
-        }
-
         public void detach () {
             var settings = AppSettings.get_default ();
-
-            // Cancel any idle that might try to touch buffer/view after we null them
-            if (image_update_idle_id != 0) {
-                GLib.Source.remove (image_update_idle_id);
-                image_update_idle_id = 0;
-            }
-            // The buffer is being abandoned — no need to surgically delete anchor
-            // chars; just drop our references so nothing tries to use them.
-            foreach (var entry in image_previews) {
-                if (entry.picture != null) {
-                    entry.picture.unparent ();
-                }
-            }
-            image_previews.clear ();
-            if (image_preview_edit_handler_id != 0 && buffer != null) {
-                SignalHandler.disconnect (buffer, image_preview_edit_handler_id);
-                image_preview_edit_handler_id = 0;
-            }
-            image_update_pending = false;
-            updating_images = false;
-            image_preview_ready = false;
-            initializing_attach = false;
-            image_preview_edit_gate = false;
 
             // Remove BibTeX completion provider if present
             if (bibtex_provider != null && view != null) {

--- a/src/Enrichments/Markdown.vala
+++ b/src/Enrichments/Markdown.vala
@@ -652,7 +652,8 @@ namespace ThiefMD.Enrichments {
             Gtk.TextIter line_end = hover_iter;
             line_start.set_line_offset (0);
             line_end.forward_to_line_end ();
-            string line_text = buffer.get_text (line_start, line_end, false);
+            // Include invisible text so collapsed markdown image URLs are still matchable.
+            string line_text = buffer.get_text (line_start, line_end, true);
             int line_offset = line_start.get_offset ();
             int hover_offset = hover_iter.get_offset ();
 

--- a/src/Enrichments/Markdown.vala
+++ b/src/Enrichments/Markdown.vala
@@ -296,8 +296,8 @@ namespace ThiefMD.Enrichments {
             try {
                 is_url = new Regex ("^(http|ftp|ssh|mailto|tor|torrent|vscode|atom|rss|file)?s?(:\\/\\/)?(www\\.)?([a-zA-Z0-9\\.\\-]+)\\.([a-z]+)([^\\s]+)$", RegexCompileFlags.CASELESS, 0);
                 is_markdown_url = new Regex ("(?<text_group>\\[(?>[^\\[\\]]+|(?&text_group))+\\])(?:\\((?<url>\\S+?)(?:[ ]\"(?<title>(?:[^\"]|(?<=\\\\)\")*?)\")?\\))", RegexCompileFlags.CASELESS, 0);
-                // Matches image tags: ![alt text](url) — used for hover tooltip preview
-                is_image = new Regex ("!\\[([^\\]]*)\\]\\(([^)]+)\\)", RegexCompileFlags.CASELESS, 0);
+                // Matches image tags: ![alt text](url) or ![alt](url "title") — used for hover tooltip preview
+                is_image = new Regex ("!\\[([^\\]]*)\\]\\(([^\\s)]+)(?:\\s[^)]*)?\\)", RegexCompileFlags.CASELESS, 0);
                 // Matches HTML image tags like: <img src="path/to/image.png" ...>
                 is_html_image = new Regex ("<img\\b[^>]*\\bsrc\\s*=\\s*[\\\"']([^\\\"']+)[\\\"'][^>]*>", RegexCompileFlags.CASELESS, 0);
             } catch (Error e) {

--- a/src/Enrichments/Markdown.vala
+++ b/src/Enrichments/Markdown.vala
@@ -594,16 +594,8 @@ namespace ThiefMD.Enrichments {
         }
 
         private bool show_image_tooltip_for_path (string img_path, Gtk.Tooltip tooltip) {
-            int max_w = 240;
-            int max_h = 200;
-            int editor_w = view.get_allocated_width ();
-            int editor_h = view.get_allocated_height ();
-            if (editor_w > 0) {
-                max_w = int.max (120, (int) (editor_w * 0.35));
-            }
-            if (editor_h > 0) {
-                max_h = int.max (90, (int) (editor_h * 0.35));
-            }
+            int max_w, max_h;
+            get_preview_max_size (out max_w, out max_h);
 
             Gdk.Texture? texture = load_preview_texture (img_path, max_w, max_h);
             if (texture == null) {
@@ -620,7 +612,20 @@ namespace ThiefMD.Enrichments {
             return true;
         }
 
-        private string resolve_tooltip_image_path (string img_url) {
+        private void get_preview_max_size (out int max_w, out int max_h) {
+            max_w = 240;
+            max_h = 200;
+            int editor_w = view.get_allocated_width ();
+            int editor_h = view.get_allocated_height ();
+            if (editor_w > 0) {
+                max_w = int.max (120, (int) (editor_w * 0.35));
+            }
+            if (editor_h > 0) {
+                max_h = int.max (90, (int) (editor_h * 0.35));
+            }
+        }
+
+        private string resolve_image_path (string img_url) {
             string img_path = Pandoc.find_file (img_url);
             if (img_path == img_url && img_url.has_prefix ("/") && img_url.length > 1) {
                 // Hugo/Jekyll style: `/images/foo.png` should resolve from project root.
@@ -668,7 +673,7 @@ namespace ThiefMD.Enrichments {
                             return false;
                         }
 
-                        string frontmatter_path = resolve_tooltip_image_path (frontmatter_url);
+                        string frontmatter_path = resolve_image_path (frontmatter_url);
                         if (frontmatter_path == frontmatter_url &&
                             !GLib.FileUtils.test (frontmatter_path, GLib.FileTest.EXISTS))
                         {
@@ -702,7 +707,7 @@ namespace ThiefMD.Enrichments {
                     }
 
                     string img_url = match_info.fetch (url_group);
-                    string img_path = resolve_tooltip_image_path (img_url);
+                    string img_path = resolve_image_path (img_url);
                     if (img_path == img_url && !GLib.FileUtils.test (img_path, GLib.FileTest.EXISTS)) {
                         continue;
                     }
@@ -1686,7 +1691,7 @@ namespace ThiefMD.Enrichments {
                 try {
                     if (is_image.match (line_text, 0, out mi)) {
                         string img_url = mi.fetch (2);
-                        string img_path = Pandoc.find_file (img_url);
+                        string img_path = resolve_image_path (img_url);
                         // find_file returns url unchanged when nothing found
                         if (img_path != img_url || GLib.FileUtils.test (img_path, GLib.FileTest.EXISTS)) {
                             pending_inserts.add (new PendingImageInsert (line_num, img_url, img_path));
@@ -1704,16 +1709,8 @@ namespace ThiefMD.Enrichments {
                 string img_url = info.img_url;
                 string img_path = info.img_path;
 
-                int max_inline_w = 240;
-                int max_inline_h = 200;
-                int editor_w = view.get_allocated_width ();
-                int editor_h = view.get_allocated_height ();
-                if (editor_w > 0) {
-                    max_inline_w = int.max (120, (int) (editor_w * 0.35));
-                }
-                if (editor_h > 0) {
-                    max_inline_h = int.max (90, (int) (editor_h * 0.35));
-                }
+                int max_inline_w, max_inline_h;
+                get_preview_max_size (out max_inline_w, out max_inline_h);
 
                 Gdk.Texture? texture = load_preview_texture (img_path, max_inline_w, max_inline_h);
                 if (texture == null) {

--- a/src/Widgets/Editor.vala
+++ b/src/Widgets/Editor.vala
@@ -733,7 +733,10 @@ namespace ThiefMD.Widgets {
         public string get_buffer_text () {
             Gtk.TextIter start, end;
             buffer.get_bounds (out start, out end);
-            return buffer.get_text (start, end, true);
+            // Strip U+FFFC (object replacement char) — that's what GTK uses to
+            // represent child anchors (like image preview widgets) in the text.
+            // We don't want those sneaking into saved markdown files!
+            return buffer.get_text (start, end, true).replace ("\xef\xbf\xbc", "");
         }
 
         public int get_buffer_word_count () {
@@ -1372,6 +1375,10 @@ namespace ThiefMD.Widgets {
 
                     string filename = file.get_path ();
                     GLib.FileUtils.get_contents (filename, out text);
+
+                    // Tear down current enrichments before replacing buffer text.
+                    // This avoids callbacks touching text regions during file open.
+                    detach_enrichments ();
                     
                     // For large files, defer markdown processing
                     bool defer_enrichments = file_size > 100000; // 100KB threshold
@@ -1406,8 +1413,7 @@ namespace ThiefMD.Widgets {
             return check.has_suffix (".md") || check.has_suffix (".markdown");
         }
 
-        private void setup_enrichments_for_file (string filename, string text) {
-            // Detach any previous enrichments before switching file types
+        private void detach_enrichments () {
             if (fountain != null) {
                 fountain.detach ();
                 fountain = null;
@@ -1416,6 +1422,11 @@ namespace ThiefMD.Widgets {
                 markdown.detach ();
                 markdown = null;
             }
+        }
+
+        private void setup_enrichments_for_file (string filename, string text) {
+            // Detach any previous enrichments before switching file types
+            detach_enrichments ();
 
             if (is_fountain (filename)) {
                 // Normalize Windows newlines for fountain parsing
@@ -1428,7 +1439,13 @@ namespace ThiefMD.Widgets {
             } else if (is_markdown_file (filename)) {
                 markdown = new MarkdownEnrichment ();
                 if (markdown.attach (this)) {
-                    markdown.recheck_all ();
+                    // Run first pass on idle so file-open text replacement settles.
+                    GLib.Idle.add (() => {
+                        if (markdown != null) {
+                            markdown.recheck_all ();
+                        }
+                        return false;
+                    });
                 }
             }
         }

--- a/src/Widgets/Editor.vala
+++ b/src/Widgets/Editor.vala
@@ -734,7 +734,7 @@ namespace ThiefMD.Widgets {
             Gtk.TextIter start, end;
             buffer.get_bounds (out start, out end);
             // Strip U+FFFC (object replacement char) — that's what GTK uses to
-            // represent child anchors (like image preview widgets) in the text.
+            // represent child anchors and embedded objects in the text.
             // We don't want those sneaking into saved markdown files!
             return buffer.get_text (start, end, true).replace ("\xef\xbf\xbc", "");
         }

--- a/src/Widgets/Sheets.vala
+++ b/src/Widgets/Sheets.vala
@@ -622,10 +622,15 @@ namespace ThiefMD.Widgets {
             save_metadata_file (true);
         }
 
-        public void update_sheet_indicators () {
+        public void update_sheet_indicators (string active_file = "") {
             foreach (var s in metadata.sheet_order) {
                 Sheet show = _sheets.get (s);
-                show.redraw ();
+                bool should_be_active = (active_file != "" && show.file_path () == active_file);
+                if (show.active_sheet != should_be_active) {
+                    show.active_sheet = should_be_active;
+                } else {
+                    show.redraw ();
+                }
             }
         }
 

--- a/src/Widgets/Sheets.vala
+++ b/src/Widgets/Sheets.vala
@@ -232,20 +232,61 @@ namespace ThiefMD.Widgets {
                 event_type == FileMonitorEvent.MOVED_IN || event_type == FileMonitorEvent.MOVED_OUT ||
                 event_type == FileMonitorEvent.DELETED || event_type == FileMonitorEvent.RENAMED)
             {
-                if (FileUtils.test (file.get_path (), FileTest.IS_DIR) || (other_file != null && FileUtils.test (other_file.get_path (), FileTest.IS_DIR))) {
-                    ThiefApp.get_instance ().library.refresh_dir (this);
+                bool refresh_library = false;
+                string? changed_path = file.get_path ();
+                string? changed_other_path = other_file != null ? other_file.get_path () : null;
+
+                if (changed_path != null && FileUtils.test (changed_path, FileTest.IS_DIR)) {
+                    refresh_library = true;
+                }
+
+                if (!refresh_library && changed_other_path != null && FileUtils.test (changed_other_path, FileTest.IS_DIR)) {
+                    refresh_library = true;
+                }
+
+                if (!refresh_library &&
+                    (event_type == FileMonitorEvent.DELETED ||
+                     event_type == FileMonitorEvent.MOVED_OUT ||
+                     event_type == FileMonitorEvent.RENAMED ||
+                     event_type == FileMonitorEvent.MOVED))
+                {
+                    string? changed_name = file.get_basename ();
+                    string? changed_other_name = other_file != null ? other_file.get_basename () : null;
+
+                    if ((changed_name != null && metadata.folder_order.contains (changed_name)) ||
+                        (changed_other_name != null && metadata.folder_order.contains (changed_other_name)))
+                    {
+                        refresh_library = true;
+                    }
+                }
+
+                debug ("Folder event=%d path=%s other=%s refresh_library=%s",
+                    (int) event_type,
+                    changed_path ?? "(null)",
+                    changed_other_path ?? "(null)",
+                    refresh_library.to_string ());
+
+                if (refresh_library) {
+                    Idle.add (() => {
+                        ThiefApp.get_instance ().library.refresh_dir (this);
+                        return false;
+                    });
                 }
 
                 File my_dir = File.new_for_path (_sheets_dir);
                 if (my_dir.query_exists ()) {
-                    refresh ();
+                    Idle.add (() => {
+                        refresh ();
+                        return false;
+                    });
                 } else {
                     _monitor.changed.disconnect (folder_changed);
-                    ThiefApp.get_instance ().library.remove_item (_sheets_dir);
+                    Idle.add (() => {
+                        ThiefApp.get_instance ().library.remove_item (_sheets_dir);
+                        return false;
+                    });
                 }
             }
-
-            // @TODO: Folder unmount support
         }
 
         public void add_hidden_item (string directory_path) {

--- a/src/Widgets/Welcome.vala
+++ b/src/Widgets/Welcome.vala
@@ -117,7 +117,8 @@ namespace ThiefMD {
             h_box.append (v_box);
 
             close_request.connect (() => {
-                return ThiefApplication.close_window (this);
+                ThiefApplication.close_window (this);
+                return false;
             });
             set_titlebar (bar);
             set_child (h_box);


### PR DESCRIPTION
This PR adds tool tip image previews when mousing over image tags in markdown. Only in experimental mode for now

<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/dd89f239-2d1a-4c65-b0c8-73f8c2b095cd" />
